### PR TITLE
Improve estimator

### DIFF
--- a/variational/basissets/ramachandran.py
+++ b/variational/basissets/ramachandran.py
@@ -1,46 +1,55 @@
 from base import BasisSet
 import numpy as np
 import itertools as it
+import os
+
 
 class RamachandranBasis(BasisSet):
 
-    def __init__(self, restype, order=2, ff='ff_AMBER99SB_ILDN', radiants=True):
+    def __init__(self, restype, order=2, ff='ff_AMBER99SB_ILDN', radians=True):
         """
         Basis set on the phi/psi torsion space of a single amino acid.
 
         Parameters
         ---------
         restype :   str
-                    Residue type, single letter code, e.g. alanine = 'A'.
+            Residue type, single letter code, e.g. alanine = 'A'.
         order : int, default=2
-                order of basis function family. 
-                Here equal to the number of nontrivial MSM eigenvectors on phi/psi space
-                to be used. The output will have order+1 columns
+            order of basis function family. Here equal to the number of
+            nontrivial MSM eigenvectors on phi/psi space to be used.
+            The output will have order+1 columns
         ff : str, default='ff_AMBER99SB_ILDN'
-             Force field to be used. Options: 'ff_AMBER99SB_ILDN' | 'ff_AMBER03' | 'ff_CHARMM27' | 'ff_OPLSAA' | 'ff_GROMOS43a1'
-             | ...
+            Force field to be used. Options: 'ff_AMBER99SB_ILDN' |
+            'ff_AMBER03' | 'ff_CHARMM27' | 'ff_OPLSAA' | 'ff_GROMOS43a1'
         radiants :  True
-                    expected inputs as radiants. If false, treats input as degrees
+            expected inputs as radiants. If false, treats input as degrees
 
         References
         ---------
         .. [5] Vitalini, F., Noe, F. and Keller, B. (2015):
-        A basis set for peptides for the variational approach to conformational kinetics. (In review).
+            A basis set for peptides for the variational approach to
+            conformational kinetics. (In revision).
+
         """
-        
+        # set parameters
         self.order = order
         self.ff = ff
-        self.radiants = radiants
-        self.RBV = np.load('ResiduesEigenvectors/Ac_'+restype+'_NHMe.npz')
+        self.radians = radians
+        # load data file
+        cwd = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
+        datafile = os.path.join(cwd, 'ResiduesEigenvectors/Ac_'+restype+'_NHMe.npz')
+        assert os.path.exists(datafile), 'Residue type ' + str(restype) + 'is not available.'
+        self.RBV = np.load(datafile)
         self.RBV = self.RBV[ff][:,:order+1]
-       
+
+
     def map(self, X):
         """
         Parameters
         ---------
         X : ndarray(T, 2)
             phi / psi angles for one residue in a  trajectory of length T
-            The array is angles in radiants between 0 and 360
+            The array is angles in radians between 0 and 360
 
         Returns
         -------
@@ -48,63 +57,65 @@ class RamachandranBasis(BasisSet):
             The basis set values, evaluated for every trajectory time point and every function order.
             The first column is always the trivial 1-function.
         """
-        binwidth=10 #binwidth
-        nbins=360/binwidth # number of bins per coordinate
-        if self.radiants==True:
-            X=X*(180/np.pi) # convert in radiants
+        binwidth = 10  # binwidth
+        nbins = 360/binwidth  # number of bins per coordinate
+        if self.radians:
+            X = X*(180/np.pi)  # convert to radians
         if np.max(X)<360:
-            X=X+180
-        X[np.nonzero(X[:,0]>=360),0]=0
-        X[np.nonzero(X[:,1]>=360),1]=0
-        X[np.nonzero(X[:,0]<0),0]=0
-        X[np.nonzero(X[:,1]<0),1]=0
-        i=np.floor(X[:,0]/binwidth) #binned phi angle
-        j=np.floor(X[:,1]/binwidth) #binned psi angle
-        n=i*(nbins)+j #n_microstates traj
-        n=np.array(n, dtype=int)
-        ev_traj=self.RBV[n,:] #project n_microstate trajectory of the monomer onto the eigenvector as ev_traj[t]=RBV[n[t]]
+            X = X+180
+        X[np.nonzero(X[:, 0]>=360), 0] = 0
+        X[np.nonzero(X[:, 1]>=360), 1] = 0
+        X[np.nonzero(X[:, 0]<0), 0] = 0
+        X[np.nonzero(X[:, 1]<0), 1] = 0
+        i = np.floor(X[:, 0] / binwidth)  # binned phi angle
+        j = np.floor(X[:, 1] / binwidth)  # binned psi angle
+        n = i*(nbins)+j  # n_microstates traj
+        n = np.array(n, dtype=int)
+        ev_traj = self.RBV[n, :]  # project n_microstate trajectory of the monomer onto the eigenvector as ev_traj[t]=RBV[n[t]]
         
         return ev_traj
 
 
 class RamachandranProductBasis(BasisSet):
 
-    def __init__(self, sequence, include_res=None, max_order=2, n_excite=2, ff='ff_AMBER99SB_ILDN', radiants=True):
+    def __init__(self, sequence, include_res=None, max_order=2, n_excite=2, ff='ff_AMBER99SB_ILDN', radians=True):
         """
         Basis set as vector product of the residue centered basis functions evaluated 
         on the phi/psi torsion space of the single amino acids.
 
         Parameters
         ---------
-        sequence :  iterable of str
-                    Residue types along the chain as single letter code, 
-                    e.g. ['A', 'G', 'A', 'G', 'V']
-        include_res :   boolian array, defaule=None
-                        Residues to include along the chain, 
-                        eg ['True', 'True', 'False', 'False', 'True']. 
-                        If not specified all residues are used.
-        max_order :     int, default=2
-                        maximum order of basis function family. 
-                        Here equal to the number of nontrivial MSM eigenvectors
-                        on phi/psi space to be used.
-        n_excite :  int, default=2
-                    number of Ramachandran basis functions allowed to be excited. 
-                    The default value (2) will allow only single and double excitations 
-                    as suggested in [5].
-                    Careful, all possible combinations (n_excite=len(sequence)) can be unmanageable. 
-                    The minimal excitation is 1, where the excited states up to max_order 
-                    are used for each amino acid in the chain.
-        ff :    str, default='ff_AMBER99SB_ILDN'
-                Force field to be used. Options: 'ff_AMBER99SB_ILDN' | 'ff_AMBER03' | 'ff_CHARMM27' | 'ff_OPLSAA' | 'ff_GROMOS43a1'
+        sequence : iterable of str
+            Residue types along the chain as single letter code,
+            e.g. ['A', 'G', 'A', 'G', 'V']
+        include_res :   boolean array, default=None
+            Residues to include along the chain,
+            e.g. ['True', 'True', 'False', 'False', 'True'].
+            If not specified all residues are used.
+        max_order : int, default=2
+            maximum order of basis function family.
+            Here equal to the number of nontrivial MSM eigenvectors
+            on phi/psi space to be used.
+        n_excite : int, default=2
+            number of Ramachandran basis functions allowed to be excited.
+            The default value (2) will allow only single and double excitations
+            as suggested in [5]. Careful, all possible combinations
+            (n_excite=len(sequence)) can be unmanageable.  The minimal
+            excitation is 1, where the excited states up to max_order
+            are used for each amino acid in the chain.
+        ff : str, default='ff_AMBER99SB_ILDN'
+            Force field to be used. Options: 'ff_AMBER99SB_ILDN' |
+            'ff_AMBER03' | 'ff_CHARMM27' | 'ff_OPLSAA' | 'ff_GROMOS43a1'
 
-        radiants :  True
-                    expected inputs as radiants. If false, treats input as degrees
+        radians : bool, default=True
+            expected inputs as radians. If false, treats input as degrees
 
 
         References
         ---------
         .. [5] Vitalini, F., Noe, F. and Keller, B. (2015):
-            A basis set for peptides for the variational approach to conformational kinetics. (In review).
+            A basis set for peptides for the variational approach to
+            conformational kinetics. (In revision).
         """
 
         self.sequence = sequence
@@ -112,29 +123,29 @@ class RamachandranProductBasis(BasisSet):
         self.max_order = max_order
         self.n_excite = n_excite
         self.ff = ff
-        self.radiants = radiants
-	
+        self.radiants = radians
+
         if self.include_res == None:
             self.include_res=np.ones(len(self.sequence), dtype=bool)
 
-        compress_ind = it.compress(self.sequence, self.include_res) # itertool object including only the residues labled as true
-        self.sequence = [item for item in compress_ind] # new sequence including only the residues labled as true
-        self.nres = len(self.sequence) # number of residues to include
-        combinations = it.combinations(np.arange(self.nres), self.n_excite) # select residues to excite
-        basis_set_list = [] # initialize list of basis functions
-        for c in combinations: # loop over combinations
+        compress_ind = it.compress(self.sequence, self.include_res)  # itertool object including only the residues labled as true
+        self.sequence = [item for item in compress_ind]  # new sequence including only the residues labled as true
+        self.nres = len(self.sequence)  # number of residues to include
+        combinations = it.combinations(np.arange(self.nres), self.n_excite)  # select residues to excite
+        basis_set_list = []  # initialize list of basis functions
+        for c in combinations:  # loop over combinations
             current_basis = np.zeros(self.nres, dtype=int) # initialize basis array
-            excitation_res = it.product(np.arange(self.max_order+1), repeat=self.n_excite)# all possible combinations of eigenvectors in the excited states
-            for p in excitation_res: # loop over the combinations of eigenvectors
-                current_basis[np.array(c)]=np.array(p) # select spots to excite
-                basis_set_list.append(np.copy(current_basis)) # add excitations to list
+            excitation_res = it.product(np.arange(self.max_order+1), repeat=self.n_excite)  # all possible combinations of eigenvectors in the excited states
+            for p in excitation_res:  # loop over the combinations of eigenvectors
+                current_basis[np.array(c)] = np.array(p)  # select spots to excite
+                basis_set_list.append(np.copy(current_basis))  # add excitations to list
         basis_set_list=np.array(basis_set_list, dtype=int)
-        #find unique elements in basis set list
+        # find unique elements in basis set list
         b = np.ascontiguousarray(basis_set_list).view(np.dtype((np.void, basis_set_list.dtype.itemsize * basis_set_list.shape[1])))
-        _, idx =np.unique(b, return_index=True)
-        unique_basis=basis_set_list[idx]
-        self.num_prod=len(unique_basis) # number of products
-        self.basis_set_list=np.array(unique_basis, dtype=int) # make list of basis functions available out of the function
+        _, idx = np.unique(b, return_index=True)
+        unique_basis = basis_set_list[idx]
+        self.num_prod = len(unique_basis)  # number of products
+        self.basis_set_list = np.array(unique_basis, dtype=int)  # make list of basis functions available out of the function
 
     def map(self, X):
         """
@@ -146,24 +157,25 @@ class RamachandranProductBasis(BasisSet):
         Returns
         -------
         Prod :  ndarray(T, n)
-                The basis set values, evaluated for every trajectory time point.
-                Each of the n elements represents a product of the residue basis
-                sets.
+            The basis set values, evaluated for every trajectory time point.
+            Each of the n elements represents a product of the residue basis
+            sets.
 
         babasis_set_list :  nparray(nprod, nres)
-                            list of basis functions as numpy array with 
-                            nprod = nuber of basis functions and 
-                            nres = number of residues
+            list of basis functions as numpy array with
+            nprod = nuber of basis functions and
+            nres = number of residues
+
         """
         
-        X=X[:,np.repeat(self.include_res, 2)] # select only residues labled as true
-        Prod=np.ones((X.shape[0],self.num_prod)) # initialize products matrix
-        q=0 # counter for the residue
-        for r in range(self.nres): # loop over residues
-            RBV=RamachandranBasis(self.sequence[r], order=self.max_order, ff=self.ff, radiants=self.radiants) # load eigenvectord for the residue
-            RBV_traj=RBV.map(X[:,q:q+2]) # project trajectory over eigenvectors
-            Prod=Prod*RBV_traj[:,self.basis_set_list[:,r]] # vectorizing over all possible states of excitations of residue r and multiplying the projected trajectory to the full product
+        X = X[:, np.repeat(self.include_res, 2)]  # select only residues labeled as true
+        Prod=np.ones((X.shape[0], self.num_prod))  # initialize products matrix
+        q = 0  # counter for the residue
+        for r in range(self.nres):  # loop over residues
+            RBV = RamachandranBasis(self.sequence[r], order=self.max_order, ff=self.ff, radians=self.radiants)  # load eigenvectord for the residue
+            RBV_traj = RBV.map(X[:, q:q+2])  # project trajectory over eigenvectors
+            Prod = Prod * RBV_traj[:, self.basis_set_list[:,r]]  # vectorizing over all possible states of excitations of residue r and multiplying the projected trajectory to the full product
             q = q + 2
 
         return Prod, self.basis_set_list
-        
+

--- a/variational/estimators/TestEstimator.py
+++ b/variational/estimators/TestEstimator.py
@@ -1,0 +1,46 @@
+import numpy as np
+import os
+import unittest
+
+import variational.estimators.lagged_correlation as lcor
+
+
+class TestEstimator(unittest.TestCase):
+    """ Performs tests for correlation matrix estimator using two long
+        trajectories from one-dimensional double-well potential and 11
+        Gaussian functions.
+            
+    """
+        
+    def setUp(self):
+        """ Load the data and construct estimator object.
+        
+        """
+        # Load the data:
+        path_local = os.path.dirname(os.path.abspath(__file__))
+        data = np.load(path_local + "/TestData.npz")
+        # Extract the pieces:
+        self.C0 = data['C0']
+        self.Ct = data['Ct']
+        self.traj0 = data['traj0']
+        self.traj1 = data['traj1']
+        # Create test object:
+        tau = 500
+        output_dimension = 11
+        self.estimator = lcor.LaggedCorrelation(output_dimension, tau)
+        # Add data to the test object:
+        self.estimator.add(self.traj0)
+        self.estimator.add(self.traj1)
+        
+    def test_Ct(self):
+        self.assertTrue(np.allclose(self.estimator.GetCt(), self.Ct))
+        
+    def test_C0(self):
+        self.assertTrue(np.allclose(self.estimator.GetC0(), self.C0))
+        
+    def test_WrongDimension(self):
+        self.assertRaises(Exception, self.estimator.add(self.traj0[:,:-1]))
+
+
+if __name__ == '__main__':
+    unittest.main()        

--- a/variational/estimators/lagged_correlation.py
+++ b/variational/estimators/lagged_correlation.py
@@ -1,33 +1,40 @@
 __author__ = 'noe'
 
+import numpy as np
+
 class LaggedCorrelation:
 
     def __init__(self, output_dimension, tau=1):
         """ Computes correlation matrices C0 and Ctau from a bunch of trajectories
+
         Parameters
         ----------
         output_dimension: int
             Number of basis functions.
         tau: int
             Lag time
+
         """
         self.tau = tau
         self.output_dimension = output_dimension
         # Initialize the two correlation matrices:
-        self.Ct = np.zeros((self.output_dimension,self.output_dimension))
-        self.C0 = np.zeros((self.output_dimension,self.output_dimension))
+        self.Ct = np.zeros((self.output_dimension, self.output_dimension))
+        self.C0 = np.zeros((self.output_dimension, self.output_dimension))
         # Also initialize the mean:
         self.mu = np.zeros(self.output_dimension)
         # Create counter for the frames used for mu, C0, Ct:
         self.nmu = 0
         self.nC0 = 0
         self.nCt = 0
+
     def add(self, X):
         """ Adds trajectory to the running estimate for computing mu, C0 and Ct:
+
         Parameters
+        ----------
         X: ndarray (T,N)
             basis function trajectory of T time steps for N basis functions.
-        ----------
+
         """
         # Raise an error if output dimension is wrong:
         
@@ -43,29 +50,36 @@ class LaggedCorrelation:
         Y = X[self.tau:,:]
         self.Ct += np.dot(X.T,Y)
         self.nCt += TX - self.tau
+
     def mean(self):
         """ Returns the mean.
+
         Returns
         -------
         mu: ndarray (N,)
             array of mean values for each of the N basis function.
+
         """
         return self.mu/self.nmu
 
     def C0(self):
         """ Returns the current estimate of C0:
+
         Returns
         -------
         C0: ndarray (N,N)
             time instantaneous correlation matrix of N basis function.
+
         """
         return self.C0/self.nC0
 
     def Ctau(self):
         """ Returns the current estimate of Ctau
+
         Returns
         -------
         Ct: ndarray (N,N)
             time lagged correlation matrix of N basis function.
+
         """
         return self.Ct/self.nCt


### PR DESCRIPTION
- This implements Fabian's corrections to the Ct / C0 estimator.
- Raises an exception if the input dimension of X in add(X) is incorrect.
- Prints a warning if X in add(X) is too short.
- Does no longer compute the mean, as we do not need it (ok?)
- Renamed methods Ctau(), C0() to GetCt() and GetC0(), to be consistent and to avoid a name clash with the variables self.Ct, self.C0.
- Also contains a first unit test using two 1d-double-well potential time series of 11 Gaussian functions.
- The tests work in principle. Only the test for the exception fails, although the right exception is raised. I guess this is easy to fix.
